### PR TITLE
Adds a :cog_env key to Spanner.Command.Request

### DIFF
--- a/lib/spanner/command/reqrep.ex
+++ b/lib/spanner/command/reqrep.ex
@@ -1,5 +1,5 @@
 defmodule Spanner.Command.Request do
-  defstruct [:room, :requestor, :command, :args, :options, :reply_to, :scope]
+  defstruct [:room, :requestor, :command, :args, :options, :reply_to, :cog_env]
 
   use Spanner.Request
 end


### PR DESCRIPTION
This just adds a special key to be used by primitive commands to store the scope of the previous command.

Partially addresses https://github.com/operable/cog/issues/23
