### PR TITLE
Fix handling of error messages that are strings

### DIFF
--- a/lib/spanner/marshalled.ex
+++ b/lib/spanner/marshalled.ex
@@ -78,7 +78,7 @@ defmodule Spanner.Marshalled do
             {:ok, populated}
           {:error, {:empty_field, field}} ->
             {:error, %{message: "#{__MODULE__}.#{field} is empty", json: data}}
-          {:error, reason} when is_bitstring(reason) ->
+          {:error, reason} when is_binary(reason) ->
             {:error, %{message: reason, json: data}}
           {:error, reason} ->
             {:error, %{message: inspect(reason), json: data}}


### PR DESCRIPTION
This PR partially addresses Issue #101.

Added a new clause to handle the error string is already a string to not inspect it.
