### PR TITLE
Validate the template json

### DIFF
--- a/lib/spanner/bundle/config_validator.ex
+++ b/lib/spanner/bundle/config_validator.ex
@@ -84,7 +84,7 @@ defmodule Spanner.Bundle.ConfigValidator do
         type
       _ ->
         raise ValidationError, field: "adapter", reason: :wrong_value,
-                               message: "Unknown adapter \'#{adapter}\'"
+                               message: "Unknown adapter '#{adapter}'"
     end
     validate_templates!(t)
   end


### PR DESCRIPTION
Instead of the template source being in the `config.json` we put the file path to a file containing the template source. 

Partial fix for https://github.com/operable/cog/issues/130
