### PR TITLE
Replace all instances of  not just one

### DIFF
--- a/lib/spanner/gen_command/foreign.ex
+++ b/lib/spanner/gen_command/foreign.ex
@@ -160,12 +160,7 @@ defmodule Spanner.GenCommand.Foreign do
   end
 
   defp maybe_bundle_dir(value, bundle_dir) do
-    case String.upcase(value) do
-      @installed_path ->
-        bundle_dir
-      _ ->
-        value
-    end
+    String.replace(value, ~r/\$INSTALL_PATH/, bundle_dir)
   end
 
   defp build_calling_env(request, %__MODULE__{bundle: bundle, command: command, bundle_dir: bundle_dir}) do


### PR DESCRIPTION
Prior code would replace the variable `$INSTALL_PATH` only if it occurred in a config variable as the lone value. For example, `"env_vars": {"PYTHONPATH": "$INSTALL_PATH"}` would correctly set `$PYTHONPATH` to the bundle's installed path. `"env_vars": {"PYTHONPATH": "$INSTALL_PATH/lib"}` failed to detect the required variable substitution and set `$PYTHONPATH` to the string literal `"$INSTALL_PATH/lib"`.

This PR fixes the behavior by using a regex to find and replace instances of `$INSTALL_PATH`.
