### PR TITLE
Interpret log output correctly

### DIFF
--- a/lib/spanner/gen_command/foreign.ex
+++ b/lib/spanner/gen_command/foreign.ex
@@ -65,6 +65,7 @@ defmodule Spanner.GenCommand.Foreign do
   end
 
   defp send_reply(request, %Porcelain.Result{status: 0, out: out}, state) do
+    out = process_log_statements(out, state.command)
     case parse_output(out, state.command) do
       {template, {:ok, content}} ->
         {:reply, request.reply_to, template, content, state}


### PR DESCRIPTION
Fixes a bug in Spanner where log output from a successfully executing command, ie one exiting with 0 status code, confused `GenCommand.Foreign` resulting in raw command output being sent to the pipeline and ultimately to the calling user.

Fixes https://github.com/operable/cog/issues/262
