### PR TITLE
Rescue command crashes

### DIFF
--- a/lib/spanner/gen_command/util.ex
+++ b/lib/spanner/gen_command/util.ex
@@ -1,0 +1,15 @@
+defmodule Spanner.GenCommand.Util do
+
+  def format_error_message(command, error, stacktrace) do
+    """
+
+    It appears that the `#{command}` command crashed while executing, with the following error:
+
+   ```#{inspect error}```
+
+   Here is the stacktrace at the point where the crash occurred. This information can help the authors of the command determine the ultimate cause for the crash.
+
+   ```#{inspect stacktrace, pretty: true}```
+   """
+  end
+end


### PR DESCRIPTION
Previously, if a GenCommand-based command ever crashed, no response
would get sent back to Cog. The only feedback the user would ever get
would come after Cog's one-minute timeout, and it would just say
`"Hmmm. The <COMMAND> command timed out."`, which is not very
helpful. Information on the crash would turn up in the logs, but it
still wasn't the greatest experience.

Now, we wrap the actual command processing in a try/rescue block; if an
error is caught, we return a detailed message with the exact error and
stacktrace back to the user.

An example (`table` shouldn't come first in a pipeline; of course, this
crash should get fixed):

```
!table --fields="foo"

Whoops! An error occurred.
It appears that the `operable:table` command crashed while executing.

The crash was due to the following error:
%ArgumentError{message: "argument error"}

Here is the stacktrace at the point where the crash occurred. This information can help the authors of the command determine the ultimate cause for the crash.

[{:erlang, :hd, [%{"fields" => ["foo"]}], []},
 {Cog.Commands.Table, :handle_message, 2,
  [file: 'lib/cog/commands/table.ex', line: 23]},
 {Spanner.GenCommand, :process_message, 4,
  [file: 'lib/spanner/gen_command.ex', line: 188]},
 {:gen_server, :try_dispatch, 4, [file: 'gen_server.erl', line: 615]},
 {:gen_server, :handle_msg, 5, [file: 'gen_server.erl', line: 681]},
 {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 240]}]
```

Commands based on `Spanner.GenCommand.Foreign` had a similar issue. If
the call to `Porcelain.exec/3` were to fail for whatever reason, an
error tuple was returned, which did not match any function heads for
`Foreign.send_reply/3`. Here we don't have to rescue anything (Porcelain
does that internally), but we can re-use the same message formatting
logic as with `GenCommand`.

As an example, once I removed the installed command file for `mist:s3-buckets` and ran that command, I now get the following result in chat:

```
!mist:s3-buckets

Whoops! An error occurred.
It appears that the `mist:s3-buckets` command crashed while executing, with the following error:

{:error, "Command not found: /Users/chris/src/operable/relay/data/bundles/mist/commands/s3_buckets.py"}

Here is the stacktrace at the point where the crash occurred. This information can help the authors of the command determine the ultimate cause for the crash.

[{Porcelain.Driver.Goon, :find_executable, 3,
  [file: 'lib/porcelain/drivers/goon_driver.ex', line: 96]},
 {Porcelain.Driver.Goon, :do_exec, 4,
  [file: 'lib/porcelain/drivers/goon_driver.ex', line: 50]},
 {Porcelain, :catch_throws, 1, [file: 'lib/porcelain.ex', line: 273]},
 {Spanner.GenCommand.Foreign, :handle_message, 2,
  [file: 'lib/spanner/gen_command/foreign.ex', line: 64]},
 {Spanner.GenCommand, :process_message, 4,
  [file: 'lib/spanner/gen_command.ex', line: 189]},
 {:gen_server, :try_dispatch, 4, [file: 'gen_server.erl', line: 615]},
 {:gen_server, :handle_msg, 5, [file: 'gen_server.erl', line: 681]},
 {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 240]}]
```

(Incidentally, this is the exact situation reported by an alpha user
this morning, and was the result of an improperly installed bundle.)

This error formatting logic is extracted to a new utilities module,
which is imported as needed.

Fixes #250
