### PR TITLE
Include cog user in Command.Request

### DIFF
--- a/lib/spanner/command/request.ex
+++ b/lib/spanner/command/request.ex
@@ -5,7 +5,7 @@ defmodule Spanner.Command.Request do
 
   require Logger
 
-  defmarshalled [:room, :requestor, :command, :args, :options, :command_config, :reply_to, :cog_env]
+  defmarshalled [:room, :requestor, :user, :command, :args, :options, :command_config, :reply_to, :cog_env]
 
   defp validate(request) do
     cond do

--- a/lib/spanner/command/request.ex
+++ b/lib/spanner/command/request.ex
@@ -57,11 +57,3 @@ defmodule Spanner.Command.Request do
   end
 
 end
-
-defmodule Spanner.Command.Response do
-
-  use Spanner.Marshalled
-
-  defmarshalled [:room, :status, :status_message, :body, :bundle, :template]
-
-end

--- a/lib/spanner/command/response.ex
+++ b/lib/spanner/command/response.ex
@@ -1,0 +1,7 @@
+defmodule Spanner.Command.Response do
+
+  use Spanner.Marshalled
+
+  defmarshalled [:room, :status, :status_message, :body, :bundle, :template]
+
+end


### PR DESCRIPTION
This will be used to consolidate cog user lookups and allow commands to receive cog user information.