### PR TITLE
Add missing optional command fields

### DIFF
--- a/lib/spanner/config/syntax_validator.ex
+++ b/lib/spanner/config/syntax_validator.ex
@@ -2,7 +2,11 @@ defmodule Spanner.Config.SyntaxValidator do
 
   alias Piper.Permissions.Parser
 
-  @schema File.read!(Path.join([:code.priv_dir(:spanner), "schemas", "bundle_config_schema.yaml"]))
+  @schema_file Path.join([:code.priv_dir(:spanner), "schemas", "bundle_config_schema.yaml"])
+
+  @external_resource @schema_file
+
+  @schema File.read!(@schema_file)
 
   @moduledoc """
   Validates bundle config syntax leveraging JsonSchema.

--- a/priv/schemas/bundle_config_schema.yaml
+++ b/priv/schemas/bundle_config_schema.yaml
@@ -58,6 +58,12 @@ definitions:
         type: string
       documentation:
         type: string
+      execution:
+        enum:
+          - once
+          - multiple
+      enforcing:
+        type: boolean
       rules:
         type: array
         items:

--- a/test/spanner/config/validator_test.exs
+++ b/test/spanner/config/validator_test.exs
@@ -17,8 +17,66 @@ defmodule Spanner.Config.Validator.Test do
     }
   end
 
+  defp enforcing_config do
+    %{"name" => "foo",
+      "version" => "0.0.1",
+      "commands" => %{
+        "bar" => %{
+          "executable" => "/bin/bar",
+          "enforcing" => true}}}
+  end
+
+  defp bad_enforcing_config do
+    %{"name" => "foo",
+      "version" => "0.0.1",
+      "commands" => %{
+        "bar" => %{
+          "executable" => "/bin/bar",
+          "enforcing" => "true"}}}
+  end
+
+  defp execution_config do
+    %{"name" => "foo",
+      "version" => "0.0.1",
+      "commands" => %{
+        "bar" => %{"executable" => "/bin/bar",
+                   "enforcing" => false,
+                   "execution" => "once"},
+        "baz" => %{"executable" => "/bin/baz",
+                   "execution" => "multiple"}}}
+  end
+
+  defp bad_execution_config do
+    %{"name" => "foo",
+      "version" => "0.0.1",
+      "commands" => %{
+        "bar" => %{"executable" => "/bin/bar",
+                   "execution" => "once"},
+        "baz" => %{"executable" => "/bin/baz",
+                   "execution" => "multi"}}}
+  end
+
+
   test "minimal config" do
     assert validate(minimal_config) == :ok
+  end
+
+  test "enforcing config" do
+    assert validate(enforcing_config) == :ok
+  end
+
+  test "bad enforcing config" do
+    assert validate(bad_enforcing_config) == {:error,
+                                              [{"Type mismatch. Expected Boolean but got String.",
+                                                "#/commands/bar/enforcing"}]}
+  end
+
+  test "execution_config" do
+    assert validate(execution_config) == :ok
+  end
+
+  test "bad_execution_config" do
+    assert validate(bad_execution_config) == {:error, [{"Value \"multi\" is not allowed in enum.", "#/commands/baz/execution"}]}
   end
 
   test "errors when permissions don't match rules" do


### PR DESCRIPTION
Added optional fields `command/execution` and `command/enforcing`. Also added `@external_resource` attribute to `lib/spanner/config/syntax_validator.ex` to ensure the module is recompiled whenever the schema file changes.