### PR TITLE
Enforce bundle config version

### DIFF
--- a/priv/schemas/bundle_config_schema.yaml
+++ b/priv/schemas/bundle_config_schema.yaml
@@ -4,6 +4,7 @@ title: Bundle Config v2
 description: A config schema for bundles
 type: object
 required:
+  - cog_bundle_version
   - name
   - version
   - commands
@@ -11,6 +12,8 @@ additionalProperties: false
 properties:
   cog_bundle_version:
     type: number
+    enum:
+      - 2
   name:
     type: string
   version:

--- a/test/spanner/config/validator_test.exs
+++ b/test/spanner/config/validator_test.exs
@@ -7,7 +7,8 @@ defmodule Spanner.Config.Validator.Test do
   end
 
   defp minimal_config do
-    %{"name" => "foo",
+    %{"cog_bundle_version" => 2,
+      "name" => "foo",
       "version" => "0.0.1",
       "commands" => %{
         "date" => %{
@@ -18,7 +19,8 @@ defmodule Spanner.Config.Validator.Test do
   end
 
   defp enforcing_config do
-    %{"name" => "foo",
+    %{"cog_bundle_version" => 2,
+      "name" => "foo",
       "version" => "0.0.1",
       "commands" => %{
         "bar" => %{
@@ -27,7 +29,8 @@ defmodule Spanner.Config.Validator.Test do
   end
 
   defp bad_enforcing_config do
-    %{"name" => "foo",
+    %{"cog_bundle_version" => 2,
+      "name" => "foo",
       "version" => "0.0.1",
       "commands" => %{
         "bar" => %{
@@ -36,7 +39,8 @@ defmodule Spanner.Config.Validator.Test do
   end
 
   defp execution_config do
-    %{"name" => "foo",
+    %{"cog_bundle_version" => 2,
+      "name" => "foo",
       "version" => "0.0.1",
       "commands" => %{
         "bar" => %{"executable" => "/bin/bar",
@@ -47,7 +51,8 @@ defmodule Spanner.Config.Validator.Test do
   end
 
   defp bad_execution_config do
-    %{"name" => "foo",
+    %{"cog_bundle_version" => 2,
+      "name" => "foo",
       "version" => "0.0.1",
       "commands" => %{
         "bar" => %{"executable" => "/bin/bar",
@@ -59,6 +64,17 @@ defmodule Spanner.Config.Validator.Test do
 
   test "minimal config" do
     assert validate(minimal_config) == :ok
+  end
+
+  test "wrong cog_bundle_version" do
+    result = update_in(minimal_config, ["cog_bundle_version"], fn(_) -> 1 end)
+    |> validate
+    assert result == {:error, [{"Value 1 is not allowed in enum.", "#/cog_bundle_version"}]}
+  end
+
+  test "missing cog_bundle_version" do
+    result = Map.delete(minimal_config, "cog_bundle_version") |> validate
+    assert result == {:error, [{"Required property cog_bundle_version was not present.", "#"}]}
   end
 
   test "enforcing config" do


### PR DESCRIPTION
This PR enforces the `cog_bundle_version` field which was previously optional. Schema changes declare this field as mandatory, numeric, and restricts allowed values to an enum.

While I was the code I also DRY'd up YAML parsing in `Spanner.Config.Parser`.