### PR TITLE
pass the config through if there is a problem with the rule fixup

### DIFF
--- a/lib/spanner/config.ex
+++ b/lib/spanner/config.ex
@@ -68,5 +68,10 @@ defmodule Spanner.Config do
       config
     end
   end
+  # We need a name and command to fix rules. If we don't have a name then there
+  # are more severe issues with the config. We can just pass the config through
+  # and let the validator inform the user what they did wrong.
+  defp update_rules(_, config),
+    do: config
 
 end

--- a/lib/spanner/config.ex
+++ b/lib/spanner/config.ex
@@ -43,8 +43,7 @@ defmodule Spanner.Config do
   @doc "Validate bundle configs"
   def validate(config) do
     with :ok <- Spanner.Config.SyntaxValidator.validate(config),
-         fixed_config <- fixup_rules(config),
-         :ok <- Spanner.Config.SemanticValidator.validate(fixed_config) do
+         :ok <- Spanner.Config.SemanticValidator.validate(fixup_rules(config)) do
       :ok
     end
   end

--- a/lib/spanner/config.ex
+++ b/lib/spanner/config.ex
@@ -42,8 +42,8 @@ defmodule Spanner.Config do
 
   @doc "Validate bundle configs"
   def validate(config) do
-    with fixed_config = fixup_rules(config),
-         :ok <- Spanner.Config.SyntaxValidator.validate(fixed_config),
+    with :ok <- Spanner.Config.SyntaxValidator.validate(config),
+         fixed_config <- fixup_rules(config),
          :ok <- Spanner.Config.SemanticValidator.validate(fixed_config) do
       :ok
     end
@@ -68,10 +68,5 @@ defmodule Spanner.Config do
       config
     end
   end
-  # We need a name and command to fix rules. If we don't have a name then there
-  # are more severe issues with the config. We can just pass the config through
-  # and let the validator inform the user what they did wrong.
-  defp update_rules(_, config),
-    do: config
 
 end

--- a/lib/spanner/config/rule_validator.ex
+++ b/lib/spanner/config/rule_validator.ex
@@ -1,0 +1,35 @@
+defmodule Spanner.Config.RuleValidator do
+
+  alias Piper.Permissions.Parser
+
+  @doc """
+  Accepts a map of commands and validates their rules
+  """
+  @spec validate(Map.t) :: :ok | {:ok, [{String.t, String.t}]}
+  def validate(commands) do
+    validate_rule_parsing(commands)
+  end
+
+  defp validate_rule_parsing(commands) when is_map(commands) do
+    Enum.flat_map(commands, &validate_rule_parsing/1)
+    |> prepare_return
+  end
+  defp validate_rule_parsing({command, %{"rules" => rules}}) do
+    Enum.with_index(rules)
+    |> Enum.reduce([], fn({rule, index}, acc) ->
+      case Parser.parse(rule) do
+        {:ok, _, _} ->
+          acc
+        {:error, err} ->
+          [{err, "#/commands/#{command}/rules/#{index}"}  | acc]
+      end
+    end)
+  end
+  defp validate_rule_parsing(_),
+    do: []
+
+  defp prepare_return([]),
+    do: :ok
+  defp prepare_return(errors),
+    do: {:error, errors}
+end

--- a/lib/spanner/config/semantic_validator.ex
+++ b/lib/spanner/config/semantic_validator.ex
@@ -37,16 +37,20 @@ defmodule Spanner.Config.SemanticValidator do
 
 
   defp validate_rule({rule, index}, bundle_name, command_name, permissions) do
-    {:ok, %Ast.Rule{}=expr, rule_permissions} = Parser.parse(rule)
-    [rule_bundle, rule_command] = String.split(expr.command, ":", parts: 2)
+    case Parser.parse(rule) do
+      {:ok, %Ast.Rule{}=expr, rule_permissions} ->
+        [rule_bundle, rule_command] = String.split(expr.command, ":", parts: 2)
 
-    errors = [validate_bundle(rule_bundle, bundle_name),
-              validate_command(rule_command, command_name),
-              validate_permissions(rule_permissions, permissions)]
+        errors = [validate_bundle(rule_bundle, bundle_name),
+                  validate_command(rule_command, command_name),
+                  validate_permissions(rule_permissions, permissions)]
 
-    errors
-    |> List.flatten
-    |> Enum.map(&{&1, "#/commands/#{command_name}/rules/#{index}"})
+        errors
+        |> List.flatten
+        |> Enum.map(&{&1, "#/commands/#{command_name}/rules/#{index}"})
+      {:error, msg} ->
+        [{msg, "#/commands/#{command_name}/rules/#{index}"}]
+    end
   end
 
   defp validate_bundle(bundle, bundle),

--- a/lib/spanner/config/syntax_validator.ex
+++ b/lib/spanner/config/syntax_validator.ex
@@ -1,7 +1,5 @@
 defmodule Spanner.Config.SyntaxValidator do
 
-  alias Piper.Permissions.Parser
-
   @schema_file Path.join([:code.priv_dir(:spanner), "schemas", "bundle_config_schema.yaml"])
 
   @external_resource @schema_file


### PR DESCRIPTION
We fixup rules by prepending the `when command is ...` bit to the rule string. The problem is that we do that before validating the config, since they need to complete rules to pass validation, and we require additional info from the bundle config to fixup the rule string. If the bundle config is not valid, we can potentially crash before ever making it to validation. If there is an issue with the rule fixup, we can just pass the config though and let the validator inform the user what they did wrong.