### PR TITLE
Updates schema for simplified calling convention

### DIFF
--- a/lib/spanner/config.ex
+++ b/lib/spanner/config.ex
@@ -70,7 +70,7 @@ defmodule Spanner.Config do
         case validate(upgraded_config) do
           {:ok, validated_config} ->
             {:warning, validated_config, warnings}
-          {:error, errors} ->
+          {:error, errors, _} ->
             {:error, errors, warnings}
         end
       {:error, errors, warnings} ->

--- a/lib/spanner/config.ex
+++ b/lib/spanner/config.ex
@@ -72,10 +72,15 @@ defmodule Spanner.Config do
   # Gets triggered when we have an old bundle config to validate
   # Upgrader will return an error if the bundle is not upgradable
   def validate(config) do
+    # Upgrader will return an upgraded config and a list of warnings
+    # or an error
     case Upgrader.upgrade(config) do
       {:ok, upgraded_config, warnings} ->
+        # We still need to validate the upgraded config
         case validate(upgraded_config) do
           {:ok, validated_config} ->
+            # If everything goes well, we return the validated config
+            # and a list of warnings.
             {:warning, validated_config, warnings}
           {:error, errors, _} ->
             {:error, errors, warnings}

--- a/lib/spanner/config.ex
+++ b/lib/spanner/config.ex
@@ -4,9 +4,12 @@ defmodule Spanner.Config do
   alias Spanner.Config.Upgrader
 
   @current_config_version 3
-  @old_config_version @current_config_version - 1
   @config_extensions [".yaml", ".yml", ".json"]
   @config_file "config"
+
+  @doc "Returns the current supported config version"
+  def current_config_version,
+    do: @current_config_version
 
   @doc "Returns a list of valid config extensions"
   def config_extensions,
@@ -66,7 +69,9 @@ defmodule Spanner.Config do
         {:error, errors, []}
     end
   end
-  def validate(%{"cog_bundle_version" => @old_config_version}=config) do
+  # Gets triggered when we have an old bundle config to validate
+  # Upgrader will return an error if the bundle is not upgradable
+  def validate(config) do
     case Upgrader.upgrade(config) do
       {:ok, upgraded_config, warnings} ->
         case validate(upgraded_config) do

--- a/lib/spanner/config.ex
+++ b/lib/spanner/config.ex
@@ -3,6 +3,8 @@ defmodule Spanner.Config do
   alias Spanner.Config.SemanticValidator
   alias Spanner.Config.Upgrader
 
+  @current_config_version 3
+  @old_config_version @current_config_version - 1
   @config_extensions [".yaml", ".yml", ".json"]
   @config_file "config"
 
@@ -50,7 +52,7 @@ defmodule Spanner.Config do
   """
   @spec validate(Map.t) ::
     {:ok, Map.t} | {:error, List.t, List.t} | {:warning, Map.t, List.t}
-  def validate(%{"cog_bundle_version" => 3}=config) do
+  def validate(%{"cog_bundle_version" => @current_config_version}=config) do
     case SyntaxValidator.validate(config) do
       :ok ->
         config = fixup_rules(config)
@@ -64,7 +66,7 @@ defmodule Spanner.Config do
         {:error, errors, []}
     end
   end
-  def validate(config) do
+  def validate(%{"cog_bundle_version" => @old_config_version}=config) do
     case Upgrader.upgrade(config) do
       {:ok, upgraded_config, warnings} ->
         case validate(upgraded_config) do

--- a/lib/spanner/config/syntax_validator.ex
+++ b/lib/spanner/config/syntax_validator.ex
@@ -21,9 +21,6 @@ defmodule Spanner.Config.SyntaxValidator do
   """
   @spec validate(Map.t, integer()) :: :ok | {:error, [{String.t, String.t}]}
   def validate(config, version \\ @current_config_version) do
-    # Note: We could validate command calling convention with ExJsonEchema
-    # but the error that it returned was less than informative so instead
-    # we just do it manually. It may be worth revisiting in the future.
     with {:ok, schema} <- load_schema(version),
          {:ok, resolved_schema} <- resolve_schema(schema),
          :ok <- ExJsonSchema.Validator.validate(resolved_schema, config),

--- a/lib/spanner/config/syntax_validator.ex
+++ b/lib/spanner/config/syntax_validator.ex
@@ -1,13 +1,16 @@
 defmodule Spanner.Config.SyntaxValidator do
 
-  @schema_file_v2 Path.join([:code.priv_dir(:spanner), "schemas", "bundle_config_schema_v2.yaml"])
-  @schema_file_v3 Path.join([:code.priv_dir(:spanner), "schemas", "bundle_config_schema_v3.yaml"])
+  @current_config_version Spanner.Config.current_config_version
+  @old_config_version @current_config_version - 1
 
-  @external_resource @schema_file_v2
-  @external_resource @schema_file_v3
+  @current_schema_file Path.join([:code.priv_dir(:spanner), "schemas", "bundle_config_schema_v#{@current_config_version}.yaml"])
+  @old_schema_file Path.join([:code.priv_dir(:spanner), "schemas", "bundle_config_schema_v#{@old_config_version}.yaml"])
 
-  @schema_v2 File.read!(@schema_file_v2)
-  @schema_v3 File.read!(@schema_file_v3)
+  @external_resource @current_schema_file
+  @external_resource @old_schema_file
+
+  @current_schema File.read!(@current_schema_file)
+  @old_schema File.read!(@old_schema_file)
 
   @moduledoc """
   Validates bundle config syntax leveraging JsonSchema.
@@ -17,7 +20,7 @@ defmodule Spanner.Config.SyntaxValidator do
   Accepts a config map and validates syntax.
   """
   @spec validate(Map.t, integer()) :: :ok | {:error, [{String.t, String.t}]}
-  def validate(config, version \\ 3) do
+  def validate(config, version \\ @current_config_version) do
     # Note: We could validate command calling convention with ExJsonEchema
     # but the error that it returned was less than informative so instead
     # we just do it manually. It may be worth revisiting in the future.
@@ -42,8 +45,8 @@ defmodule Spanner.Config.SyntaxValidator do
     end
   end
 
-  defp load_schema(2),
-    do: Spanner.Config.Parser.read_from_string(@schema_v2)
+  defp load_schema(@old_config_version),
+    do: Spanner.Config.Parser.read_from_string(@old_schema)
   defp load_schema(_),
-    do: Spanner.Config.Parser.read_from_string(@schema_v3)
+    do: Spanner.Config.Parser.read_from_string(@current_schema)
 end

--- a/lib/spanner/config/upgrader.ex
+++ b/lib/spanner/config/upgrader.ex
@@ -1,0 +1,113 @@
+defmodule Spanner.Config.Upgrader do
+  alias Spanner.Config.SyntaxValidator
+
+  @moduledoc """
+  Attempts to upgrade bundle config to current version.
+  """
+
+  @current_version 3
+  @upgradable_versions [2]
+
+  @doc """
+  When possible upgrades config to the current version. Returns the upgraded
+  config and a list of warnings for deprecated config options or an error if
+  the upgrade fails.
+  """
+  @spec upgrade(Map.t) :: {:ok, Map.t, List.t} | {:error, List.t}
+  def upgrade(%{"cog_bundle_version" => version}=config) when version in @upgradable_versions do
+    deprecation_msg =
+      {"""
+       Bundle config version #{version} has been deprecated. \
+       Please update to version #{@current_version}.\
+       """,
+       "#/cog_bundle_version"}
+    # We run the validator for the old version here. So if the user passes an
+    # old version that is also invalid, we don't crash trying to access fields
+    # that don't exist.
+    case SyntaxValidator.validate(config, version) do
+      :ok ->
+        do_upgrade(config)
+        |> insert_deprecation_msg(deprecation_msg)
+      {:error, errors} ->
+        {:error, errors, [deprecation_msg]}
+    end
+  end
+  def upgrade(_) do
+    {:error, {[], [{"Cog bundle version not supported", "#/cog_bundle_version"}]}}
+  end
+
+  defp do_upgrade(config) do
+    case execution_once?(config["commands"]) do
+      {true, {warnings, errors}} ->
+        {:error, errors, warnings}
+      {false, warnings} ->
+        {enforce_warnings, updated_commands} = update_enforcing(config["commands"])
+        updated_config = %{config | "commands" => updated_commands}
+        |> Map.put("cog_bundle_version", @current_version)
+        {:ok, updated_config, warnings ++ enforce_warnings}
+    end
+  end
+
+  # Checks to see if the execution field exists in the bundle config. If it
+  # does but contains "multiple" we just return a warning. If it contains
+  # "once" we return an error.
+  defp execution_once?(commands) do
+    {warnings, errors} = Enum.reduce(commands, {[],[]},
+      fn
+        ({cmd_name, cmd}, {warnings, errors}) ->
+          case Map.get(cmd, "execution", nil) do
+            "once" ->
+              msg = "Execution 'once' commands are no longer supported"
+              location = "#/commands/#{cmd_name}/execution"
+              updated_errors = [{msg, location} | errors]
+              {warnings, updated_errors}
+            "multiple" ->
+              msg = "Execution type has been deprecated. Please update your bundle config"
+              location = "#/commands/#{cmd_name}/execution"
+              updated_warnings = [{msg, location} | warnings]
+              {updated_warnings, errors}
+            nil ->
+              {warnings, errors}
+          end
+      end)
+
+    if length(errors) > 0 do
+      {true, {warnings, errors}}
+    else
+      {false, warnings}
+    end
+
+  end
+
+  # Updates for non enforcing commands. If 'enforcing: false' is specified we
+  # add the "allow" rule, delete the enforcing field and return a warning. If
+  # 'enforcing: true' is specified we return a warning and delete the field.
+  defp update_enforcing(commands) do
+    Enum.reduce(commands, {[], commands},
+      fn
+        ({cmd_name, %{"enforcing" => enforcing}=cmd}, {warnings, commands}) when not(enforcing) ->
+          msg = "Non-enforcing commands have been deprecated. Please update your bundle config"
+          updated_warnings = [{msg, "#/commands/#{cmd_name}/enforcing"} | warnings]
+
+          updated_cmd = Map.put(cmd, "rules", ["allow"])
+          |> Map.delete("enforcing")
+          updated_commands = Map.put(commands, cmd_name, updated_cmd)
+
+          {updated_warnings, updated_commands}
+        ({cmd_name, %{"enforcing" => _}=cmd}, {warnings, commands}) ->
+          msg = "The 'enforcing' field has been deprecated. Please update your bundle config"
+          updated_warnings = [{msg, "#/commands/#{cmd_name}/enforcing"} | warnings]
+
+          updated_cmd = Map.delete(cmd, "enforcing")
+          updated_commands = Map.put(commands, cmd_name, updated_cmd)
+
+          {updated_warnings, updated_commands}
+        (_, acc) ->
+          acc
+      end)
+  end
+
+  defp insert_deprecation_msg({status, errors, warnings}, msg) do
+    {status, errors, [msg | warnings]}
+  end
+end

--- a/lib/spanner/config/upgrader.ex
+++ b/lib/spanner/config/upgrader.ex
@@ -32,8 +32,25 @@ defmodule Spanner.Config.Upgrader do
         {:error, errors, [deprecation_msg]}
     end
   end
+  # If we get an un-upgradable version, let the user know.
+  def upgrade(%{"cog_bundle_version" => version}) do
+    {:error,
+     [{"""
+       cog_bundle_version #{version} is not supported. \
+       Please update your bundle config to version #{@current_version}.\
+       """,
+       "#/cog_bundle_version"}],
+     []}
+  end
+  # If we don't get a version, let the user know.
   def upgrade(_) do
-    {:error, {[], [{"Cog bundle version not supported", "#/cog_bundle_version"}]}}
+    {:error,
+     [{"""
+       cog_bundle_version not specified. You must specify a valid bundle \
+       version. The current version is #{@current_version}.\
+       """,
+       "#/cog_bundle_version"}],
+     []}
   end
 
   defp do_upgrade(config) do

--- a/lib/spanner/config/upgrader.ex
+++ b/lib/spanner/config/upgrader.ex
@@ -5,7 +5,7 @@ defmodule Spanner.Config.Upgrader do
   Attempts to upgrade bundle config to current version.
   """
 
-  @current_version 3
+  @current_version Spanner.Config.current_config_version
   @upgradable_version @current_version - 1
 
   @doc """

--- a/lib/spanner/config/upgrader.ex
+++ b/lib/spanner/config/upgrader.ex
@@ -6,7 +6,7 @@ defmodule Spanner.Config.Upgrader do
   """
 
   @current_version 3
-  @upgradable_versions [2]
+  @upgradable_version @current_version - 1
 
   @doc """
   When possible upgrades config to the current version. Returns the upgraded
@@ -14,7 +14,7 @@ defmodule Spanner.Config.Upgrader do
   the upgrade fails.
   """
   @spec upgrade(Map.t) :: {:ok, Map.t, List.t} | {:error, List.t}
-  def upgrade(%{"cog_bundle_version" => version}=config) when version in @upgradable_versions do
+  def upgrade(%{"cog_bundle_version" => version}=config) when version == @upgradable_version do
     deprecation_msg =
       {"""
        Bundle config version #{version} has been deprecated. \
@@ -79,7 +79,10 @@ defmodule Spanner.Config.Upgrader do
               updated_errors = [{msg, location} | errors]
               {warnings, updated_errors}
             "multiple" ->
-              msg = "Execution type has been deprecated. Please update your bundle config"
+              msg = """
+              Execution type has been deprecated. \
+              Please update your bundle config to version #{@current_version}.\
+              """
               location = "#/commands/#{cmd_name}/execution"
               updated_warnings = [{msg, location} | warnings]
               {updated_warnings, errors}
@@ -103,7 +106,10 @@ defmodule Spanner.Config.Upgrader do
     Enum.reduce(commands, {[], commands},
       fn
         ({cmd_name, %{"enforcing" => enforcing}=cmd}, {warnings, commands}) when not(enforcing) ->
-          msg = "Non-enforcing commands have been deprecated. Please update your bundle config"
+          msg = """
+          Non-enforcing commands have been deprecated. \
+          Please update your bundle config to version #{@current_version}.\
+          """
           updated_warnings = [{msg, "#/commands/#{cmd_name}/enforcing"} | warnings]
 
           updated_cmd = Map.put(cmd, "rules", ["allow"])
@@ -112,7 +118,10 @@ defmodule Spanner.Config.Upgrader do
 
           {updated_warnings, updated_commands}
         ({cmd_name, %{"enforcing" => _}=cmd}, {warnings, commands}) ->
-          msg = "The 'enforcing' field has been deprecated. Please update your bundle config"
+          msg = """
+          The 'enforcing' field has been deprecated. \
+          Please update your bundle config to version #{@current_version}.\
+          """
           updated_warnings = [{msg, "#/commands/#{cmd_name}/enforcing"} | warnings]
 
           updated_cmd = Map.delete(cmd, "enforcing")

--- a/priv/schemas/bundle_config_schema.yaml
+++ b/priv/schemas/bundle_config_schema.yaml
@@ -56,17 +56,12 @@ definitions:
     type: object
     required:
       - executable
+      - rules
     properties:
       executable:
         type: string
       documentation:
         type: string
-      execution:
-        enum:
-          - once
-          - multiple
-      enforcing:
-        type: boolean
       rules:
         type: array
         items:

--- a/priv/schemas/bundle_config_schema_v2.yaml
+++ b/priv/schemas/bundle_config_schema_v2.yaml
@@ -56,12 +56,17 @@ definitions:
     type: object
     required:
       - executable
-      - rules
     properties:
       executable:
         type: string
       documentation:
         type: string
+      execution:
+        enum:
+          - once
+          - multiple
+      enforcing:
+        type: boolean
       rules:
         type: array
         items:

--- a/priv/schemas/bundle_config_schema_v3.yaml
+++ b/priv/schemas/bundle_config_schema_v3.yaml
@@ -13,7 +13,6 @@ properties:
   cog_bundle_version:
     type: number
     enum:
-      - 2
       - 3
   name:
     type: string

--- a/priv/schemas/bundle_config_schema_v3.yaml
+++ b/priv/schemas/bundle_config_schema_v3.yaml
@@ -1,0 +1,101 @@
+---
+"$schema": http://json-schema.org/draft-04/schema#
+title: Bundle Config v3
+description: A config schema for bundles
+type: object
+required:
+  - cog_bundle_version
+  - name
+  - version
+  - commands
+additionalProperties: false
+properties:
+  cog_bundle_version:
+    type: number
+    enum:
+      - 2
+      - 3
+  name:
+    type: string
+  version:
+    type: string
+    pattern: ^\d+\.\d+($|\.\d+$)
+  permissions:
+    type: array
+    items:
+      type: string
+  docker:
+    type: object
+    required:
+      - image
+      - tag
+    properties:
+      image:
+        type: string
+      tag:
+        type: string
+  templates:
+    type: object
+    additionalProperties:
+      "$ref": "#/definitions/template"
+  commands:
+    type: object
+    additionalProperties:
+      "$ref": "#/definitions/command"
+
+############# DEFINITIONS #################
+definitions:
+  template:
+    type: object
+    additionalProperties: false
+    properties:
+      slack:
+        type: string
+      hipchat:
+        type: string
+  command:
+    type: object
+    required:
+      - executable
+      - rules
+    properties:
+      executable:
+        type: string
+      documentation:
+        type: string
+      rules:
+        type: array
+        items:
+          type: string
+      env_vars:
+        type: object
+        additionalProperties:
+          type:
+            - string
+            - boolean
+            - number
+      options:
+        type: object
+        additionalProperties:
+          "$ref": "#/definitions/command_option"
+  command_option:
+    type: object
+    required:
+      - type
+    properties:
+      type:
+        type: string
+        enum:
+          - int
+          - float
+          - bool
+          - string
+          - incr
+          - list
+      description:
+        type: string
+      required:
+        type: boolean
+      short_flag:
+        type: string
+

--- a/priv/schemas/bundle_config_schema_v3.yaml
+++ b/priv/schemas/bundle_config_schema_v3.yaml
@@ -55,6 +55,7 @@ definitions:
         type: string
   command:
     type: object
+    additionalProperties: false
     required:
       - executable
       - rules
@@ -82,6 +83,7 @@ definitions:
     type: object
     required:
       - type
+    additionalProperties: false
     properties:
       type:
         type: string

--- a/test/spanner/config/validator_test.exs
+++ b/test/spanner/config/validator_test.exs
@@ -145,7 +145,7 @@ defmodule Spanner.Config.Validator.Test do
                  "rules" => ["when command is foo:date allow"]}},
              } = config
     assert [{"Bundle config version 2 has been deprecated. Please update to version 3.", "#/cog_bundle_version"},
-            {"Non-enforcing commands have been deprecated. Please update your bundle config", "#/commands/date/enforcing"}] = warnings
+            {"Non-enforcing commands have been deprecated. Please update your bundle config to version 3.", "#/commands/date/enforcing"}] = warnings
   end
 
   # env_vars can be strings, booleans and numbers


### PR DESCRIPTION
This removes the enforcing and execution fields from the command schema and adds a requirement for rules. In order to support version 2 to some extent I added a new module, `Spanner.Config.Upgrader` that attempts to upgrade version 2 bundles to version 3. It will abort with an error if the bundle it is trying to upgrade contains a `once` command.

This also changes the validator's return signature a bit. It will return `{:ok, config}` like before in the success case but now will also return `{:warning, config, warnings}` if the bundle was upgraded. `warnings` of course contains a list of warning messages encountered during the upgrade. The failure case changed a bit as well, now we return `{:error, errors, warnings}`, errors containing the list of errors and warnings containing the list of warnings in the case of an attempted upgrade.

Since the return signature changed we will also need to update cog and cogctl at merge.

resolves https://github.com/operable/cog/issues/623