### PR TITLE
Update for the modern world

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Spanner.Mixfile do
   def project do
     [app: :spanner,
      version: "0.13.0",
-     elixir: "~> 1.2",
+     elixir: "~> 1.3.1",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      deps: deps]
@@ -17,11 +17,10 @@ defmodule Spanner.Mixfile do
 
   defp deps do
     [{:piper, github: "operable/piper"},
-
-     # For yaml parsing. yaml_elixir is a wrapper around yamerl which is a native erlang lib.
-     {:yaml_elixir, "~> 1.0.0"},
-     {:yamerl, github: "yakaz/yamerl"},
-
-     {:ex_json_schema, "~> 0.3.1"}]
+     {:yaml_elixir, "~> 1.2"},
+     # yaml_elixir should define this, but the current release isn't
+     # pulling it from Hex. Once it does, we can remove this.
+     {:yamerl, "0.3.2"},
+     {:ex_json_schema, "~> 0.5"}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
-%{"ex_json_schema": {:hex, :ex_json_schema, "0.3.1", "d0430262816dc61e19b9dab8ee747994ad18db151cdd63485334885835fe67cc", [:mix], []},
-  "piper": {:git, "https://github.com/operable/piper.git", "4bd80f3820d184d989dbb058db4141847eea8449", []},
+%{"ex_json_schema": {:hex, :ex_json_schema, "0.5.1", "83356e5a673d6fbe75da612a44b8f84942711630414d8be5e342f3597b03939a", [:mix], []},
+  "piper": {:git, "https://github.com/operable/piper.git", "d2aa3e936408f95c965c88c9a4c684bd965262ab", []},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},
-  "uuid": {:hex, :uuid, "1.1.3", "06ca38801a1a95b751701ca40716bb97ddf76dfe7e26da0eec7dba636740d57a", [:mix], []},
-  "yamerl": {:git, "https://github.com/yakaz/yamerl.git", "ae810a808817d9482b4628ae3e20d746e3729fe0", []},
-  "yaml_elixir": {:hex, :yaml_elixir, "1.0.0", "a0b703148aa8926a08fc14619c83e9cdf7555ff7e8bb9e74c08aa716eaf8c609", [:mix], []}}
+  "uuid": {:hex, :uuid, "1.1.4", "36c7734e4c8e357f2f67ba57fb61799d60c20a7f817b104896cca64b857e3686", [:mix], []},
+  "yamerl": {:hex, :yamerl, "0.3.2", "9eac1537d251e926f47763ab1db0d9e6e8f2397646c290d58aa6ceebc6832fb7", [:rebar3], []},
+  "yaml_elixir": {:hex, :yaml_elixir, "1.2.0", "6b7a1d82f00d536831f5f1dfa2aad4f71138059336e513efefdb5f9c20ddb281", [:mix], []}}


### PR DESCRIPTION
* Update `ex_json_schema`
* Update `yaml_elixir`, pull `yamerl` from Hex
* Use Elixir 1.3.1