### PR TITLE
adds an option config section to bundle schema

### DIFF
--- a/priv/schemas/bundle_config_schema_v4.yaml
+++ b/priv/schemas/bundle_config_schema_v4.yaml
@@ -47,6 +47,27 @@ properties:
         type: array
         items:
           type: string
+  config:
+    type: object
+    optional:
+      - notes
+      - env
+    properties:
+      notes:
+        type: string
+      env:
+        type: array
+        items:
+          type: object
+          required:
+            - var
+          optional:
+            - description
+          properties:
+            description:
+              type: string
+            var:
+              type: string
   templates:
     type: object
     patternProperties:


### PR DESCRIPTION
Adds an optional config section to bundle configs. Since this is an optional section we aren't bumping the config version.

The config section contains two fields that contain info about configuring the bundle. The first is a `notes` field that takes a string. This is just for general information about bundle config. The second field is called `env` and contains a list of objects with two fields: var, for the variable name, and description, for an optional description.

Both `notes` and `env` are optional.

Example:
```
...
config:
  notes:
    The cfn bundle makes use of CloudFormation stack templates and stack policies that are
    defined in JSON documents and stored in pre-defined S3 locations. These locations are
    defined with the 'CFN_TEMPLATE_URL' and 'CFN_POLICY_URL' configuration variables.
  env:
    - var: AWS_REGION
    - var: AWS_ACCESS_KEY_ID
    - var: AWS_SECRET_ACCESS_KEY
    - var: AWS_STS_ROLE_ARN
      description: STS role ARN that should be assumed. Defined as 'arn:aws:iam::<account_number>:role/<role_name>'.
    - var: CFN_TEMPLATE_URL
      description: S3 Location of your stack templates. Defined as 's3://<bucket>/<path>'.
    - var: CFN_POLICY_URL
      description: S3 Location of your stack policies. Defined as 's3://<bucket>/<path>'.
...
```

reference https://github.com/operable/cog/issues/948 and https://github.com/operable/cog/pull/1011