### PR TITLE
Remove C++ compile dependencies

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,7 +1,4 @@
 FROM operable/elixir:1.3.1-r4
 
-# Greenbar-only compilation dependencies
-RUN apk -U add expat-dev gcc g++ libstdc++
-
 WORKDIR /code
 COPY . /code


### PR DESCRIPTION
Not quite sure what I was thinking; `spanner` doesn't depend on
`greenbar`!