### PR TITLE
Update yaml_elixir to 1.2.1

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -18,9 +18,6 @@ defmodule Spanner.Mixfile do
   defp deps do
     [{:piper, github: "operable/piper"},
      {:yaml_elixir, "~> 1.2"},
-     # yaml_elixir should define this, but the current release isn't
-     # pulling it from Hex. Once it does, we can remove this.
-     {:yamerl, "0.3.2"},
      {:ex_json_schema, "~> 0.5"}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -3,4 +3,4 @@
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},
   "uuid": {:hex, :uuid, "1.1.4", "36c7734e4c8e357f2f67ba57fb61799d60c20a7f817b104896cca64b857e3686", [:mix], []},
   "yamerl": {:hex, :yamerl, "0.3.2", "9eac1537d251e926f47763ab1db0d9e6e8f2397646c290d58aa6ceebc6832fb7", [:rebar3], []},
-  "yaml_elixir": {:hex, :yaml_elixir, "1.2.0", "6b7a1d82f00d536831f5f1dfa2aad4f71138059336e513efefdb5f9c20ddb281", [:mix], []}}
+  "yaml_elixir": {:hex, :yaml_elixir, "1.2.1", "4a8ee3b25598100c710ff11dde4d79b6335608ac092d69aab45cc7475b5abc4d", [:mix], [{:yamerl, "~> 0.3.2", [hex: :yamerl, optional: false]}]}}


### PR DESCRIPTION
It now pulls in yamerl from Hex, so we no longer need to manually
track that.