### PR TITLE
Change output to an object rather than a string

### DIFF
--- a/priv/schemas/bundle_config_schema_v4.yaml
+++ b/priv/schemas/bundle_config_schema_v4.yaml
@@ -110,7 +110,15 @@ definitions:
         additionalProperties:
           type: string
       output:
-        type: string
+        type: object
+        optional:
+          - description
+          - example
+        properties:
+          description:
+            type: string
+          example:
+            type: string
       rules:
         type: array
         items:


### PR DESCRIPTION
We haven't yet released Cog with the previous `output` value being a string. It's not ideal, but it should be fine to change it to an object without bumping a schema version.