### PR TITLE
Bump configuration version to 5

### DIFF
--- a/lib/spanner/config.ex
+++ b/lib/spanner/config.ex
@@ -6,8 +6,13 @@ defmodule Spanner.Config do
   # does not require a version bump, but adding new mandatory fields,
   # or changing the overall structure of the configuration file does
   # require a bump
-
-  @current_config_version 4
+  #
+  # Also of note: strictly speaking, this version also needs to
+  # encompass the notion of the execution environment the bundle is
+  # intended to operate in. We don't really have a formal way to
+  # represent that right now, so it can end up getting folded into
+  # this version number.
+  @current_config_version 5
   @old_config_version @current_config_version - 1
   @config_extensions [".yaml", ".yml", ".json"]
   @config_file "config"

--- a/priv/schemas/bundle_config_schema_v5.yaml
+++ b/priv/schemas/bundle_config_schema_v5.yaml
@@ -1,21 +1,28 @@
 ---
 "$schema": http://json-schema.org/draft-04/schema#
-title: Bundle Config v3
+title: Bundle Config v5
 description: A config schema for bundles
 type: object
 required:
   - cog_bundle_version
   - name
+  - description
   - version
   - commands
 properties:
   cog_bundle_version:
     type: number
     enum:
-      - 3
+      - 5
   name:
     type: string
   description:
+    type: string
+  long_description:
+    type: string
+  author:
+    type: string
+  homepage:
     type: string
   version:
     type: string
@@ -40,10 +47,33 @@ properties:
         type: array
         items:
           type: string
+  config:
+    type: object
+    optional:
+      - notes
+      - env
+    properties:
+      notes:
+        type: string
+      env:
+        type: array
+        items:
+          type: object
+          required:
+            - var
+          optional:
+            - description
+          properties:
+            description:
+              type: string
+            var:
+              type: string
   templates:
     type: object
-    additionalProperties:
-      "$ref": "#/definitions/template"
+    patternProperties:
+      "^[A-Za-z0-9_]+$":
+        "$ref": "#/definitions/template"
+    additionalProperties: false
   commands:
     type: object
     additionalProperties:
@@ -53,12 +83,12 @@ properties:
 definitions:
   template:
     type: object
-    additionalProperties: false
     properties:
-      slack:
+      body:
         type: string
-      hipchat:
-        type: string
+    required:
+      - body
+    additionalProperties: false
   command:
     type: object
     required:
@@ -69,8 +99,26 @@ definitions:
         type: string
       description:
         type: string
-      documentation:
+      long_description:
         type: string
+      examples:
+        type: string
+      arguments:
+        type: string
+      subcommands:
+        type: object
+        additionalProperties:
+          type: string
+      output:
+        type: object
+        optional:
+          - description
+          - example
+        properties:
+          description:
+            type: string
+          example:
+            type: string
       rules:
         type: array
         items:
@@ -107,4 +155,3 @@ definitions:
         type: boolean
       short_flag:
         type: string
-

--- a/test/spanner/config/v4_validator_test.exs
+++ b/test/spanner/config/v4_validator_test.exs
@@ -58,12 +58,12 @@ defmodule Spanner.Config.V4ValidatorTest do
   test "wrong cog_bundle_version" do
     result = update_in(minimal_config, ["cog_bundle_version"], fn(_) -> 1 end)
     |> validate
-    assert result == {:error, [{"cog_bundle_version 1 is not supported. Please update your bundle config to version 4.", "#/cog_bundle_version"}], []}
+    assert result == {:error, [{"cog_bundle_version 1 is not supported. Please update your bundle config to version #{Spanner.Config.current_config_version}.", "#/cog_bundle_version"}], []}
   end
 
   test "missing cog_bundle_version" do
     result = Map.delete(minimal_config, "cog_bundle_version") |> validate
-    assert result == {:error, [{"cog_bundle_version not specified. You must specify a valid bundle version. The current version is 4.", "#/cog_bundle_version"}], []}
+    assert result == {:error, [{"cog_bundle_version not specified. You must specify a valid bundle version. The current version is #{Spanner.Config.current_config_version}.", "#/cog_bundle_version"}], []}
   end
 
   test "incomplete rules" do


### PR DESCRIPTION
This officially removes support for v3 bundles (the last to support
Mustache templates).

There are currently no structural changes that differentiate v4
bundles from v5; this increment is more a reflection of a change in
the execution environment these bundles are meant to run in. We don't
currently have a formal mechanism to represent such environmental
changes. Until such time as we do, the bundle configuration version
should be understood to encompass both structural features of the
configuration file _and_ their execution environment.

(Note, however, that v5 will not be finalized until Cog 1.0 is
released in mid January 2017; structural changes to the configuration
file schema may be added between now and then.)

Some tests for v4 were updated so they better capture the behavior being
tested (that is, we're testing that users are urged to update to the
latest valid configuration version).